### PR TITLE
install headers to CATKIN_PACKAGE_INCLUDE_DESTINATION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ catkin_package(
   INCLUDE_DIRS include
   DEPENDS Eigen)
 
-install(DIRECTORY include/
-        DESTINATION include
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
         FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
satisfy catkin_lint and enable alternativ install destinations
