### PR TITLE
Fix eigen3 depends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(eigen_stl_containers)
 
 find_package(catkin REQUIRED)
+
+# we don't build anything here, but in order to export the right
+# build flags in catkin_package(), we still have to find Eigen3 here
+find_package(Eigen3 REQUIRED)
+
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS Eigen)
+  DEPENDS EIGEN3)
 
 install(DIRECTORY include/
         DESTINATION include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(catkin REQUIRED)
 # build flags in catkin_package(), we still have to find Eigen3 here
 find_package(Eigen3 REQUIRED)
 
+# eigen 3.2 (wily) only provdies EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
 catkin_package(
   INCLUDE_DIRS include
   DEPENDS EIGEN3)

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>eigen</build_depend>
   <run_depend>eigen</run_depend>
 
 </package>


### PR DESCRIPTION
In addition to  #5, fixed EIGEN3_INCLUDE_DIRS problem, reported at https://github.com/ros/robot_model/issues/149

Xenial uses eigen 3.5, where as Willy uses 3.2 and 3.2 only provides EIGEN3_INCLUDE_DIR where eigen 3.5 provides EIGEN3_INCLUDE_DIRS
otherwise will have following warning and could not build as reporeted at https://github.com/ros/robot_model/issues/149
```
Warnings   << eigen_stl_containers:check /home/catkin_ws/logs/eigen_stl_containers/build.check.001.log                             
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'EIGEN' but neither 'EIGEN_INCLUDE_DIRS' nor
  'EIGEN_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:7 (catkin_package)

```