### PR TITLE
Switch over to package XML format version 2

### DIFF
--- a/include/eigen_stl_containers/eigen_stl_map_container.h
+++ b/include/eigen_stl_containers/eigen_stl_map_container.h
@@ -42,20 +42,21 @@
 
 #include <map>
 #include <string>
+#include <functional>
 
 namespace EigenSTL
 {
 
-typedef std::map<std::string, Eigen::Vector3d, std::less<std::string>, 
+typedef std::map<std::string, Eigen::Vector3d, std::less<std::string>,
                  Eigen::aligned_allocator<std::pair<const std::string, Eigen::Vector3d> > > map_string_Vector3d;
 
-typedef std::map<std::string, Eigen::Vector3f, std::less<std::string>, 
+typedef std::map<std::string, Eigen::Vector3f, std::less<std::string>,
                  Eigen::aligned_allocator<std::pair<const std::string, Eigen::Vector3f> > > map_string_Vector3f;
 
-typedef std::map<std::string, Eigen::Affine3d, std::less<std::string>, 
+typedef std::map<std::string, Eigen::Affine3d, std::less<std::string>,
                  Eigen::aligned_allocator<std::pair<const std::string, Eigen::Affine3d> > > map_string_Affine3d;
 
-typedef std::map<std::string, Eigen::Affine3f, std::less<std::string>, 
+typedef std::map<std::string, Eigen::Affine3f, std::less<std::string>,
                  Eigen::aligned_allocator<std::pair<const std::string, Eigen::Affine3f> > > map_string_Affine3f;
 
 }

--- a/include/eigen_stl_containers/eigen_stl_vector_container.h
+++ b/include/eigen_stl_containers/eigen_stl_vector_container.h
@@ -58,5 +58,4 @@ typedef std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3
 
 }
 
-
 #endif

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
-<package>
+<package format="2">
   <name>eigen_stl_containers</name>
   <version>0.1.8</version>
-  
+
   <description>This package provides a set of typedef's that allow
   using Eigen datatypes in STL containers</description>
   <author email="isucan@willowgarage.com">Ioan Sucan</author>
@@ -17,6 +17,6 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
-  <run_depend>eigen</run_depend>
 
+  <build_export_depend>eigen</build_export_depend>
 </package>


### PR DESCRIPTION
This makes it more compatible with ROS2.  Also minor fixups while we are in here, to cleanup trailing whitespace, include headers where necessary, and remove an unnecessary run/exec dependency on eigen (eigen is a header-only library, so by definition it is only needed at build time).